### PR TITLE
Add deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Add a method to remove the monkey patches.
   [gforcada]
 
+- End Of Life: starting with Plone 5.1.0 release collective.indexing has been merged into Plone core.
+  The functionality provided by it is already available
+  [gforcada]
+
 
 2.0b1 - 2013-02-16
 ------------------

--- a/src/collective/indexing/__init__.py
+++ b/src/collective/indexing/__init__.py
@@ -1,4 +1,12 @@
+import warnings
 
+warnings.warn(
+    '2.0b1 was the last release of collective.indexing. '
+    'Starting with Plone 5.1.0 its code has already merged in. '
+    'For more information and upgrade information, see its PLIP: '
+    'https://github.com/plone/Products.CMFPlone/issues/1343',
+    DeprecationWarning,
+)
 
 def initialize(context):
     # apply the monkey patches...


### PR DESCRIPTION
If PLIP 1343 gets merged a new release of collective.indexing needs to be done
with this commit merged.

It displays a warning on bin/instance fg so that users know that they should
move away from collective.indexing as soon as they update to Plone 5.X.Y.

References:
https://github.com/plone/Products.CMFPlone/issues/1343
