### PR TITLE
Test this package against Plone 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ downloads
 eggs
 include
 lib
+local
 parts
 htmlcov
 var

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Test the package against Plone 4.3
+  [ale-rt]
 
 2.0 (2017-04-13)
 ----------------

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -16,112 +16,195 @@
 Simply run this script in a directory containing a buildout.cfg.
 The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
-
-$Id$
 """
 
-import os, shutil, sys, tempfile, urllib2
+import os
+import shutil
+import sys
+import tempfile
+
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
 
-is_jython = sys.platform.startswith('java')
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
-# parsing arguments
-parser = OptionParser(
-    'This is a custom version of the zc.buildout %prog script.  It is '
-    'intended to meet a temporary need if you encounter problems with '
-    'the zc.buildout 1.5 release.')
-parser.add_option("-v", "--version", dest="version", default='1.4.4',
-                          help='Use a specific zc.buildout version.  *This '
-                          'bootstrap script defaults to '
-                          '1.4.4, unlike usual buildpout bootstrap scripts.*')
-parser.add_option("-d", "--distribute",
-                   action="store_true", dest="distribute", default=False,
-                   help="Use Disribute rather than Setuptools.")
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
 
-parser.add_option("-c", None, action="store", dest="config_file",
-                   help=("Specify the path to the buildout configuration "
-                         "file to be used."))
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
+
+######################################################################
+# load/install setuptools
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+ez = {}
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
+cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+requirement = 'zc.buildout'
+version = options.buildout_version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
+ws.require(requirement)
+import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
 
 # if -c was provided, we push it back into args for buildout' main function
 if options.config_file is not None:
-    args += ['-c', options.config_file]
+    args[0:0] = ['-c', options.config_file]
 
-if options.version is not None:
-    VERSION = '==%s' % options.version
-else:
-    VERSION = ''
-
-USE_DISTRIBUTE = options.distribute
-args = args + ['bootstrap']
-
-to_reload = False
-try:
-    import pkg_resources
-    if not hasattr(pkg_resources, '_distribute'):
-        to_reload = True
-        raise ImportError
-except ImportError:
-    ez = {}
-    if USE_DISTRIBUTE:
-        exec urllib2.urlopen('http://python-distribute.org/distribute_setup.py'
-                         ).read() in ez
-        ez['use_setuptools'](to_dir=tmpeggs, download_delay=0, no_fake=True)
-    else:
-        exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
-                             ).read() in ez
-        ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
-
-    if to_reload:
-        reload(pkg_resources)
-    else:
-        import pkg_resources
-
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
-        else:
-            return c
-else:
-    def quote (c):
-        return c
-
-ws  = pkg_resources.working_set
-
-if USE_DISTRIBUTE:
-    requirement = 'distribute'
-else:
-    requirement = 'setuptools'
-
-env = dict(os.environ,
-           PYTHONPATH=
-           ws.find(pkg_resources.Requirement.parse(requirement)).location
-           )
-
-cmd = [quote(sys.executable),
-       '-c',
-       quote('from setuptools.command.easy_install import main; main()'),
-       '-mqNxd',
-       quote(tmpeggs)]
-
-if 'bootstrap-testing-find-links' in os.environ:
-    cmd.extend(['-f', os.environ['bootstrap-testing-find-links']])
-
-cmd.append('zc.buildout' + VERSION)
-
-if is_jython:
-    import subprocess
-    exitcode = subprocess.Popen(cmd, env=env).wait()
-else: # Windows prefers this, apparently; otherwise we would prefer subprocess
-    exitcode = os.spawnle(*([os.P_WAIT, sys.executable] + cmd + [env]))
-assert exitcode == 0
-
-ws.add_entry(tmpeggs)
-ws.require('zc.buildout' + VERSION)
-import zc.buildout.buildout
 zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,14 @@
 [buildout]
-extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-4.1.x.cfg
+extends = https://raw.githubusercontent.com/collective/buildout.plonetest/master/plone-4.3.x.cfg
 package-name = collective.indexing
+parts +=
+    test
 
 [test]
 recipe = collective.xmltestreport
 eggs =
-    collective.indexing
-    ${instance:eggs}
+    collective.indexing [test]
+
+[versions]
+setuptools = 38.5.1
+zc.buildout = 2.11.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 
 version = '2.1.dev0'
 
@@ -39,7 +41,6 @@ setup(name = 'collective.indexing',
       extras_require = {
             'test': [
                   'plone.app.testing',
-                  'unittest2',
             ]
       },
       entry_points = """

--- a/src/collective/indexing/tests/base.py
+++ b/src/collective/indexing/tests/base.py
@@ -1,12 +1,11 @@
-import unittest2 as unittest
-
+from collective.indexing.tests import layer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 
-from collective.indexing.tests import layer
+import unittest
 
 
 class Helper(unittest.TestCase):

--- a/src/collective/indexing/tests/browser.txt
+++ b/src/collective/indexing/tests/browser.txt
@@ -64,7 +64,7 @@ Plone calls them redundantly after all:
   >>> len(queuedIndex) > len(calledIndex)
   True
   >>> len(calledIndex)
-  2
+  3
 
 Let's make sure the new item has actually been indexed, that is added to the
 portal catalog:
@@ -96,7 +96,7 @@ the hook into the transaction machinery:
 Now both should be in the catalog and show up in the global sections:
 
   >>> len(calledIndex)
-  4
+  6
   >>> path = lambda obj: '/'.join(obj.getPhysicalPath())
   >>> def sort(brains):
   ...     return sorted([ brain.getObject() for brain in brains ], key=path)
@@ -116,9 +116,9 @@ And the search should of course also return the new news:
   >>> browser.getControl('Search Site').value = 'today'
   >>> browser.getForm(action='search').submit()
   >>> browser.url
-  'http://nohost/plone/search?SearchableText=today'
+  'http://nohost/plone/@@search?SearchableText=today'
   >>> browser.contents
-  '...Search results...2 items matching your search terms...'
+  '...Search results...<strong id="search-results-number">2</strong>...items matching your search terms...'
 
 Now let's try some other operations, for example moving items around.  The
 change of location should be correctly reflected by the catalog.  First some
@@ -130,7 +130,7 @@ preparations including more counters for reindexing and unindexing operations:
   >>> browser.getControl('Save').click()
 
   >>> len(calledIndex)
-  6
+  9
   >>> calledIndex[:] = []
   >>> uid = portal['first-news-today'].UID()
   >>> folder = portal['a-folder']
@@ -315,10 +315,10 @@ Renaming should also work, but let's reset the counters first:
   <ATFolder at /plone/some-news>
 
   >>> sorted(calledIndex)
-  ['<ATFolder at /plone/some-news>', '<ATNewsItem at /plone/some-news/second-news-today>']
+  ['<ATFolder at /plone/some-news>', '<ATFolder at /plone/some-news>', '<ATNewsItem at /plone/some-news/second-news-today>', '<ATNewsItem at /plone/some-news/second-news-today>']
 
   >>> sorted(calledReindex)
-  ['<PloneSite at /plone>']
+  ['<ATNewsItem at /plone/some-news/second-news-today>', '<ATNewsItem at /plone/some-news/second-news-today>', '<PloneSite at /plone>']
 
   >>> sorted(calledUnindex)
   ['<PathWrapper at /plone/a-folder/second-news-today>', '<PathWrapper at /plone/a-folder>']
@@ -327,24 +327,6 @@ Renaming should also work, but let's reset the counters first:
   []
   >>> sort(catalog(getId='some-news'))
   [<ATFolder at /plone/some-news>]
-
-Adding a criterion to a collection shouldn't catalog the criterion:
-
-  >>> browser.getLink('Home').click()
-  >>> browser.getLink(url='createObject?type_name=Topic').click()
-  >>> browser.getControl(name='title').value = 'a collection'
-  >>> browser.getControl('Save').click()
-  >>> browser.getLink('Criteria').click()
-  >>> browser.getForm(name='criteria_select').getControl('Item Type').selected = True
-  >>> browser.getForm(name='criteria_select').getControl('Select content types').selected = True
-  >>> browser.getControl('Add criteria').click()
-
-  >>> portal['a-collection']
-  <ATTopic at /plone/a-collection>
-  >>> portal['a-collection'].objectIds()
-  ['syndication_information', 'crit__Type_ATPortalTypeCriterion']
-  >>> catalog(portal_type='ATPortalTypeCriterion')
-  []
 
 Also the portal site object itself should never be indexed:
 

--- a/src/collective/indexing/tests/moveonwftransition.txt
+++ b/src/collective/indexing/tests/moveonwftransition.txt
@@ -47,18 +47,11 @@ Now we'll create a folder where we want to move our item to:
 Next we create a content rule, which will move the object to our destination
 folder whenever a workflow transition happens:
 
-  >>> browser.getLink('Rules').click()
-  >>> browser.getLink('content rules control panel').click()
+  >>> browser.open('http://nohost/plone/@@rules-controlpanel')
   >>> browser.getControl('Add content rule').click()
   >>> browser.getControl('Title').value = 'Move on workflow transition'
   >>> browser.getControl('Triggering event').displayValue = ['Workflow state changed']
   >>> browser.getControl('Save').click()
-
-We're back at the control panel.  Now we'll edit the content rule:
-
-  >>> browser.url
-  'http://nohost/plone/@@rules-controlpanel'
-  >>> browser.getLink('Move on workflow transition (Workflow state changed)').click()
 
 Now comes the action, we want all objects to be moved to the destination
 folder:

--- a/src/collective/indexing/tests/test_integration.py
+++ b/src/collective/indexing/tests/test_integration.py
@@ -1,9 +1,12 @@
-from Acquisition import aq_parent, aq_inner, aq_base
+# coding=utf-8
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from collective.indexing.tests.base import IndexingTestCase
 from Products.ATContentTypes.content.event import ATEvent
+from Products.ATContentTypes.criteria.portaltype import ATPortalTypeCriterion
 from Products.CMFCore.utils import getToolByName
 from transaction import commit
-
-from collective.indexing.tests.base import IndexingTestCase
 
 
 def getEventSubject(self):
@@ -71,7 +74,10 @@ class PathWrapperTests(IndexingTestCase):
         obj = self.folder
         wrapper = wrap(obj)
         self.assertEqual(aq_parent(wrapper), aq_parent(obj))
-        self.assertEqual(aq_parent(aq_inner(wrapper)), aq_parent(aq_inner(obj)))
+        self.assertEqual(
+            aq_parent(aq_inner(wrapper)),
+            aq_parent(aq_inner(obj)),
+        )
         # also check an extended aq-chain
         obj = self.folder.__of__(self.portal.news)
         wrapper = wrap(obj)
@@ -81,7 +87,9 @@ class PathWrapperTests(IndexingTestCase):
         # re-wrap itself in the parent's context or containment (aka "inner")
         # chain (in queue.py:70).  this can probably be fixed by using
         # `__parent__`, but not before zope 2.12...
-        # self.assertEqual(aq_parent(aq_inner(wrapper)), aq_parent(aq_inner(obj)))
+        # self.assertEqual(
+        #     aq_parent(aq_inner(wrapper)), aq_parent(aq_inner(obj))
+        # )
 
 
 class OverriddenIndexMethodTests(IndexingTestCase):
@@ -110,8 +118,8 @@ class OverriddenIndexMethodTests(IndexingTestCase):
         self.failIf(getOwnIndexMethod(event, 'reindexObject'))
         self.failIf(getOwnIndexMethod(event, 'unindexObject'))
         # while a criterion has private methods...
-        container.invokeFactory('Topic', id='coll')
-        crit = container.coll.addCriterion('Type', 'ATPortalTypeCriterion')
+        container.invokeFactory('Collection', id='coll')
+        crit = ATPortalTypeCriterion('crit')
         self.failUnless(getOwnIndexMethod(crit, 'indexObject'))
         self.failUnless(getOwnIndexMethod(crit, 'reindexObject'))
         self.failUnless(getOwnIndexMethod(crit, 'unindexObject'))


### PR DESCRIPTION
The test suite was failing when using `http://svn.plone.org/svn/collective/buildout/plonetest/test-4.1.x.cfg` because of an import move (zope.globalrequest).
So I switched to Plone 4.3.

Some tests had to be adapted because on Plone 4.3 we do not have Topic anymore out of the box and the rules control panel behavior changed.
Apparently since Plone 4.1 there is something that is triggering the queue processing, this also required to update some tests.