### PR TITLE
Avoid to call queue.process a second time when indexing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Avoid to call queue.process a second time when indexing.
+  [sgeulette]
 
 2.1 (2018-07-20)
 ----------------

--- a/src/collective/indexing/config.py
+++ b/src/collective/indexing/config.py
@@ -5,6 +5,8 @@ UNINDEX = -1
 REINDEX = 0
 INDEX = 1
 
+processing = set()
+
 
 class IndexingConfig(Persistent):
     # BBB: support uninstall of 1.x versions

--- a/src/collective/indexing/queue.py
+++ b/src/collective/indexing/queue.py
@@ -6,14 +6,13 @@ from Acquisition import aq_base, aq_inner, aq_parent
 
 from collective.indexing.interfaces import IIndexQueue
 from collective.indexing.interfaces import IIndexQueueProcessor
-from collective.indexing.config import INDEX, REINDEX, UNINDEX
+from collective.indexing.config import INDEX, REINDEX, UNINDEX, processing
 from collective.indexing.transactions import QueueTM
 
 debug = getLogger('collective.indexing.queue').debug
 
 
 localQueue = None
-processing = set()
 
 
 class InvalidQueueOperation(Exception):
@@ -25,6 +24,7 @@ def getQueue():
     global localQueue
     if localQueue is None:
         localQueue = IndexQueue()
+        processing.clear()
     return localQueue
 
 

--- a/src/collective/indexing/transactions.py
+++ b/src/collective/indexing/transactions.py
@@ -1,8 +1,10 @@
+from collective.indexing.config import processing
 from logging import getLogger
 from threading import local
-from transaction.interfaces import ISavepointDataManager
 from transaction import get as getTransaction
+from transaction.interfaces import ISavepointDataManager
 from zope.interface import implements
+
 
 logger = getLogger('collective.indexing.transactions')
 
@@ -49,8 +51,10 @@ class QueueTM(local):
         pass
 
     def before_commit(self):
+        processing.add(self.queue)
         self.queue.process()
         self.queue.clear()
+        processing.remove(self.queue)
 
     def tpc_vote(self, transaction):
         pass


### PR DESCRIPTION
Solution for issue #20.
Need ideally a specific test to verify duplication absence.